### PR TITLE
Main Search Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,9 @@ kotlin.sourceSets.all {
 }
 
 dependencies {
+
+    def accompanist_version = '0.24.7-alpha'
+
     // UI
     implementation "androidx.compose.runtime:runtime:$compose_version"
     implementation 'androidx.activity:activity-compose:1.5.1'
@@ -68,6 +71,12 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.core:core-splashscreen:1.0.0'
     implementation "androidx.navigation:navigation-compose:2.5.2"
+
+    //Accompanist / Google navigation for compose
+    implementation "com.google.accompanist:accompanist-navigation-animation:$accompanist_version"
+    implementation "com.google.accompanist:accompanist-systemuicontroller:$accompanist_version"
+    implementation "com.google.accompanist:accompanist-pager:$accompanist_version"
+    implementation "com.google.accompanist:accompanist-placeholder-material:$accompanist_version"
 
     // Logging
     implementation 'com.jakewharton.timber:timber:5.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MercadoSearch">
         <activity
-            android:name=".MainActivity"
+            android:name=".MainSearchActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.MercadoSearch.SplashScreen"

--- a/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
@@ -11,11 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.sandoval.mercadosearch.ui.search_products.screens.MercadoSearchNavigation
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainSearchActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -25,17 +26,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    Text(text = "Hello Mercado Search!")
+                    MercadoSearchNavigation()
                 }
             }
         }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    MercadoSearchTheme {
-        Text(text = "Hello Mercado Search!")
     }
 }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/compose/SearchTextField.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/compose/SearchTextField.kt
@@ -1,0 +1,163 @@
+package com.sandoval.mercadosearch.ui.compose
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun RectangleSearchTextField(
+    searchTextValue: TextFieldValue,
+    enabled: Boolean,
+    doWhenSearchedTextChanged: (TextFieldValue) -> Unit,
+    doWhenSearchButtonClicked: () -> Unit,
+    doWhenFocused: (() -> Unit)? = null,
+    doWhenFocusLost: (() -> Unit)? = null
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    SearchTextField(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(elevation = 4.dp, shape = RectangleShape),
+        enabled = enabled,
+        lockContent = true,
+        shape = RectangleShape,
+        searchTextValue = searchTextValue,
+        leadingIcon = {},
+        doWhenSearchedTextChanged = doWhenSearchedTextChanged,
+        doWhenSearchActionClicked = doWhenSearchButtonClicked,
+        doWhenFocused = doWhenFocused,
+        doWhenFocusLost = doWhenFocusLost
+    )
+}
+
+@Composable
+fun RoundedSearchTextField(
+    padding: PaddingValues = PaddingValues(),
+    searchTextValue: TextFieldValue,
+) {
+    SearchTextField(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(padding)
+            .shadow(elevation = 8.dp, shape = RoundedCornerShape(percent = 50)),
+        searchTextValue = searchTextValue,
+        shape = RoundedCornerShape(percent = 50),
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = "Search Icon"
+            )
+        },
+        doWhenSearchedTextChanged = { },
+        doWhenSearchActionClicked = { }
+    )
+}
+
+@Composable
+fun SearchTextField(
+    modifier: Modifier,
+    searchTextValue: TextFieldValue,
+    shape: Shape,
+    leadingIcon: @Composable (() -> Unit),
+    doWhenSearchedTextChanged: (TextFieldValue) -> Unit,
+    doWhenSearchActionClicked: () -> Unit,
+    enabled: Boolean = true,
+    lockContent: Boolean = false,
+    doWhenFocused: (() -> Unit)? = null,
+    doWhenFocusLost: (() -> Unit)? = null,
+) {
+
+    val focusManager = LocalFocusManager.current
+    val searchTextFocusRequester = remember { FocusRequester() }
+    var focusState by remember { mutableStateOf(true) }
+    var requestedNewContent by remember { mutableStateOf(false) }
+    val previousValue by remember { mutableStateOf(searchTextValue.text) }
+    TextField(modifier = modifier.then(
+        Modifier
+            .focusable()
+            .focusRequester(searchTextFocusRequester)
+            .onFocusChanged { state ->
+                if (state.hasFocus) {
+                    doWhenFocused?.invoke()
+                } else {
+                    if (lockContent && requestedNewContent.not()
+                        && (searchTextValue.text.isBlank() || searchTextValue.text != previousValue)
+                    ) {
+                        doWhenSearchedTextChanged(TextFieldValue(previousValue))
+                    }
+                    doWhenFocusLost?.invoke()
+                }
+                focusState = state.hasFocus
+            }
+    ),
+        enabled = enabled,
+        colors = TextFieldDefaults.textFieldColors(
+            backgroundColor = Color.White,
+            textColor = Color.Black,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent
+        ),
+        value = searchTextValue,
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.Sentences,
+            imeAction = ImeAction.Search
+        ),
+        keyboardActions = KeyboardActions(onSearch = {
+            if (searchTextValue.text.isBlank().not()) {
+                requestedNewContent = true
+                doWhenSearchActionClicked()
+            }
+            focusManager.clearFocus(force = true)
+        }),
+        leadingIcon = leadingIcon,
+        trailingIcon = {
+            if (focusState) {
+                if (searchTextValue.text.isBlank().not()) {
+                    IconButton(onClick = {
+                        doWhenSearchedTextChanged(TextFieldValue())
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Clear text"
+                        )
+                    }
+                }
+            }
+        },
+        placeholder = {
+            Text(
+                text = "Busca un producto",
+                maxLines = 1
+            )
+        },
+        shape = shape,
+        onValueChange = { text -> doWhenSearchedTextChanged(text) })
+}

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/compose/TextFieldSave.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/compose/TextFieldSave.kt
@@ -1,0 +1,16 @@
+package com.sandoval.mercadosearch.ui.compose
+
+import androidx.compose.runtime.saveable.mapSaver
+import androidx.compose.ui.text.input.TextFieldValue
+
+val textFieldSaver = run {
+    val valueKey = "value"
+    mapSaver(
+        save = { mapOf(valueKey to it.text) },
+        restore = {
+            TextFieldValue(it[valueKey].run {
+                if (this is String) this else ""
+            })
+        }
+    )
+}

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/MercadoSearchNavigation.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/MercadoSearchNavigation.kt
@@ -1,0 +1,46 @@
+package com.sandoval.mercadosearch.ui.search_products.screens
+
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.runtime.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.text.input.TextFieldValue
+import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.composable
+import com.google.accompanist.systemuicontroller.SystemUiController
+import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.sandoval.mercadosearch.ui.theme.MercadoSearchYellow
+import com.sandoval.mercadosearch.ui.compose.textFieldSaver
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun MercadoSearchNavigation() {
+
+    val navigationController = rememberAnimatedNavController()
+    val systemUiController = rememberSystemUiController()
+
+    var searchTextValue by rememberSaveable(stateSaver = textFieldSaver) {
+        mutableStateOf(TextFieldValue())
+    }
+
+    AnimatedNavHost(navigationController, startDestination = Route.SEARCH.name) {
+        composable(Route.SEARCH.name) {
+            SetStatusBarColor(systemUiController = systemUiController, MercadoSearchYellow)
+            SearchProductScreen(
+                searchTextValue = searchTextValue
+            )
+        }
+    }
+}
+
+@Composable
+private fun SetStatusBarColor(systemUiController: SystemUiController, color: Color) {
+    SideEffect {
+        systemUiController.setStatusBarColor(color)
+    }
+}
+
+enum class Route {
+    SEARCH, RESULTS, DETAILS, FEATURES
+}

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchProductScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchProductScreen.kt
@@ -1,0 +1,95 @@
+package com.sandoval.mercadosearch.ui.search_products.screens
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sandoval.mercadosearch.ui.compose.RectangleSearchTextField
+import com.sandoval.mercadosearch.ui.compose.RoundedSearchTextField
+import com.sandoval.mercadosearch.ui.theme.*
+
+@Composable
+fun SearchProductScreen(
+    searchTextValue: TextFieldValue
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MercadoSearchYellow)
+            .verticalScroll(rememberScrollState()),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(getMaxContentWidth()),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                textAlign = TextAlign.Center,
+                text = "Bienvenido a Mercado Search!",
+                style = Typography.h5
+            )
+            Text(
+                modifier = Modifier.padding(top = 8.dp),
+                textAlign = TextAlign.Center,
+                text = "Compra todo lo que necesites al mejor precio"
+            )
+            RoundedSearchTextField(
+                padding = PaddingValues(top = 32.dp),
+                searchTextValue = searchTextValue
+            )
+        }
+    }
+}
+
+/**
+ * Retorna el porcentaje de la pantalla que representa el maximo ancho
+ * del componente composable padre que contiene todos los widgets dentro
+ * de la jerarquia. La configuracion actual retorna asi:
+ *
+ * 65% Para orientacion landscape
+ * 85% Para orientacion vertical
+ *
+ * @return percentage
+ */
+
+@Composable
+private fun getMaxContentWidth(): Float {
+    val localConfiguration = LocalConfiguration.current
+    return if (localConfiguration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+        0.65f
+    } else {
+        0.85f
+    }
+}
+
+@Preview(name = "Portrait")
+@Preview(name = "Landscape", device = Devices.PIXEL_4_XL, widthDp = 720, heightDp = 360)
+@Composable
+fun SearchProductScreenPreviewPortrait() {
+    MercadoSearchTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colors.background
+        ) {
+            SearchProductScreen(searchTextValue = TextFieldValue())
+        }
+    }
+}


### PR DESCRIPTION
- Add to the gradle the dependencies regarding the google advice to use navigation routes and animations in jetpack compose (google accompanist)
- Add the router to enable navigation in the app. Set the default main screen as the search product screen
- Add the first design approach to type and search a product
- Create a compose package to store the composable objects to be used across the application
- Use the main activity as the single responsible to set the navigation routes and the default launch screen