### PR TITLE
Add Data Consume to Results Screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     def retrofit = '2.9.0'
     def accompanist_version = '0.24.7-alpha'
 
+    // Lifecycle
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.compose.runtime:runtime-livedata:1.3.0-beta02'
+
     // UI
     implementation "androidx.compose.runtime:runtime:$compose_version"
     implementation 'androidx.activity:activity-compose:1.5.1'

--- a/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -30,6 +31,7 @@ class MainSearchActivity : ComponentActivity() {
                     color = MaterialTheme.colors.background
                 ) {
                     MercadoSearchNavigation(
+                        searchState = viewModel.searchState.observeAsState(),
                         mercadoSearchNavigationActions = setupActions()
                     )
                 }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/compose/ErrorComposable.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/compose/ErrorComposable.kt
@@ -1,0 +1,47 @@
+package com.sandoval.mercadosearch.ui.compose
+
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.graphics.Color
+import com.sandoval.mercadosearch.ui.base.ErrorUIModel
+import com.sandoval.mercadosearch.ui.theme.MercadoSearchAmaranthRed
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.lang.Error
+
+@Composable
+fun ErrorSnackbarHost(snackbarHostState: SnackbarHostState) {
+    SnackbarHost(hostState = snackbarHostState) { snackbarData ->
+        Snackbar(
+            contentColor = Color.White,
+            actionColor = Color.White,
+            backgroundColor = MercadoSearchAmaranthRed,
+            snackbarData = snackbarData
+        )
+    }
+}
+
+@Composable
+fun ShowErrorSnackBar(
+    coroutineScope: CoroutineScope,
+    snackbarHostState: SnackbarHostState,
+    error: ErrorUIModel,
+    doWhenActionPerformed: () -> Unit
+) {
+    LaunchedEffect(
+        key1 = snackbarHostState,
+        block = {
+            coroutineScope.launch {
+                val result = snackbarHostState.showSnackbar(
+                    message = error.getWarningMessage(),
+                    actionLabel = error.suggestedAction,
+                    duration = SnackbarDuration.Indefinite
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    doWhenActionPerformed()
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
@@ -21,10 +21,12 @@ import com.sandoval.mercadosearch.ui.compose.textFieldSaver
 import com.sandoval.mercadosearch.ui.search_products.screens.SearchProductScreen
 import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultScreen
 import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultsActions
+import com.sandoval.mercadosearch.ui.viewmodel.state.ProductSearchState
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun MercadoSearchNavigation(
+    searchState: State<ProductSearchState?>,
     mercadoSearchNavigationActions: MercadoSearchNavigationActions
 ) {
 
@@ -64,6 +66,7 @@ fun MercadoSearchNavigation(
             SetStatusBarColor(systemUiController = systemUiController, color = Color.White)
             SearchResultScreen(
                 searchTextValue = searchTextValue,
+                searchState = searchState.value,
                 actions = searchResultActions(
                     searchTextValue,
                     mercadoSearchNavigationActions,
@@ -80,6 +83,11 @@ private fun searchResultActions(
     mercadoSearchNavigation: MercadoSearchNavigationActions,
     navigationController: NavHostController
 ) = SearchResultsActions(
+    doWhenSearchActionClicked = {
+        mercadoSearchNavigation.doWhenSearchActionClicked(
+            searchTextValue.text
+        )
+    },
     doWhenBackButtonClicked = mercadoSearchNavigation.doWhenBackButtonPressed
 )
 

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchResultsScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchResultsScreen.kt
@@ -4,6 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -12,19 +15,26 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.sandoval.mercadosearch.ui.compose.ErrorSnackbarHost
 import com.sandoval.mercadosearch.ui.compose.RectangleSearchTextField
-import com.sandoval.mercadosearch.ui.search_products.screens.preview.searchResultActions
+import com.sandoval.mercadosearch.ui.compose.ShowErrorSnackBar
+import com.sandoval.mercadosearch.ui.search_products.screens.preview.*
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
 import com.sandoval.mercadosearch.ui.theme.Typography
+import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
+import com.sandoval.mercadosearch.ui.viewmodel.state.ProductSearchState
 
 @Composable
 fun SearchResultScreen(
     searchTextValue: TextFieldValue,
+    searchState: ProductSearchState?,
     actions: SearchResultsActions
 ) {
+    val coroutineScope = rememberCoroutineScope()
     val scaffoldState = rememberScaffoldState()
     var searchFocusState by remember { mutableStateOf(true) }
     Scaffold(
@@ -35,12 +45,13 @@ fun SearchResultScreen(
                 searchTextValue,
                 enabled = true,
                 doWhenSearchedTextChanged = {},
-                doWhenSearchButtonClicked = { /*TODO*/ },
+                doWhenSearchButtonClicked = actions.doWhenSearchActionClicked,
                 doWhenBackButtonClicked = actions.doWhenBackButtonClicked,
                 doWhenFocused = { searchFocusState = true },
                 doWhenFocusLost = { searchFocusState = false },
             )
-        }
+        },
+        snackbarHost = { snackbarHostState -> ErrorSnackbarHost(snackbarHostState = snackbarHostState) }
     ) { paddingValues ->
         Box(
             modifier = Modifier
@@ -48,6 +59,39 @@ fun SearchResultScreen(
                 .background(Color.White)
                 .padding(bottom = paddingValues.calculateBottomPadding())
         ) {
+            when (searchState) {
+                ProductSearchState.Loading -> LoadingSection()
+                ProductSearchState.NoResults -> NoResultsFoundSection()
+                is ProductSearchState.Results -> {
+                    ProductsListSection(
+                        searchState.products
+                    )
+                    searchState.refreshingError?.let { error ->
+                        ShowErrorSnackBar(
+                            coroutineScope,
+                            scaffoldState.snackbarHostState,
+                            error
+                        ) {
+                            //TODO intentar cargar mas items
+                        }
+                    }
+                }
+                is ProductSearchState.Failure -> {
+                    with(searchState.error) {
+                        FailureSection(generalPurposeMessage)
+                        if (!criticalMessage.isNullOrBlank()) {
+                            ShowErrorSnackBar(
+                                coroutineScope,
+                                scaffoldState.snackbarHostState,
+                                searchState.error
+                            ) {
+                                actions.doWhenSearchActionClicked()
+                            }
+                        }
+                    }
+                }
+                else -> {}
+            }
             if (searchFocusState) {
                 Box(
                     modifier = Modifier
@@ -59,9 +103,47 @@ fun SearchResultScreen(
                         ) {}
                 )
             }
-            NoResultsFoundSection()
         }
     }
+}
+
+@Composable
+private fun LoadingSection() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(modifier = Modifier.size(60.dp))
+    }
+}
+
+@Composable
+private fun ProductsListSection(
+    products: List<ProductDataUIModel>
+) {
+    val lazyListState = rememberLazyListState()
+    LazyColumn(
+        state = lazyListState
+    ) {
+        items(
+            items = products,
+            key = { product -> product.id }) { product ->
+            Row(
+                modifier = Modifier.clickable { },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text(
+                        modifier = Modifier.padding(start = 8.dp, top = 16.dp, end = 16.dp),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        text = product.name
+                    )
+                }
+            }
+        }
+    }
+
 }
 
 @Composable
@@ -84,19 +166,62 @@ private fun NoResultsFoundSection() {
     }
 }
 
+@Composable
+private fun FailureSection(message: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        //TODO Colocar una imagen de error
+        Spacer(modifier = Modifier.fillMaxHeight(0.10f))
+        Text(
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp),
+            text = message,
+            style = Typography.h6
+        )
+    }
+}
+
 data class SearchResultsActions(
+    val doWhenSearchActionClicked: () -> Unit,
     val doWhenBackButtonClicked: () -> Unit
 )
+
+@Preview(name = "LoadingStateState")
+@Composable
+fun SearchResultsScreenLoadingStateStatePreview() {
+    BuildSearchResultsPreview(searchResultsLoading)
+}
+
+@Preview(name = "ResultsState")
+@Preview(name = "Landscape", device = Devices.PIXEL_4_XL, widthDp = 720, heightDp = 360)
+@Composable
+fun SearchResultsScreenResultsStatePreview() {
+    BuildSearchResultsPreview(searchResults)
+}
 
 @Preview(name = "NoResultsState")
 @Preview(name = "Landscape", device = Devices.PIXEL_4_XL, widthDp = 720, heightDp = 360)
 @Composable
 fun SearchResultsScreenNoResultsStatePreview() {
-    BuildSearchResultsPreview()
+    BuildSearchResultsPreview(searchResultsNoResults)
+}
+
+@Preview(name = "ResultsFailureState")
+@Composable
+fun SearchResultsScreenResultsFailureStatePreview() {
+    BuildSearchResultsPreview(searchResultsRefreshingError)
+}
+
+@Preview(name = "FailureState")
+@Preview(name = "Landscape", device = Devices.PIXEL_4_XL, widthDp = 720, heightDp = 360)
+@Composable
+fun SearchResultsScreenFailureStatePreview() {
+    BuildSearchResultsPreview(searchResultsFailure)
 }
 
 @Composable
-fun BuildSearchResultsPreview() {
+fun BuildSearchResultsPreview(state: ProductSearchState) {
     MercadoSearchTheme() {
         Surface(
             modifier = Modifier.fillMaxSize(),
@@ -105,6 +230,7 @@ fun BuildSearchResultsPreview() {
             SearchResultScreen(
                 searchTextValue = TextFieldValue(),
                 actions = searchResultActions,
+                searchState = state
             )
         }
     }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
@@ -1,6 +1,69 @@
 package com.sandoval.mercadosearch.ui.search_products.screens.preview
 
+import com.sandoval.mercadosearch.ui.base.ErrorUIModel
 import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultsActions
+import com.sandoval.mercadosearch.ui.viewmodel.mapper.DProductDataModelToUIModel
+import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
+import com.sandoval.mercadosearch.ui.viewmodel.state.ProductSearchState
+
+
+val error =
+    ErrorUIModel(generalPurposeMessage = "Something went wrong", suggestedAction = "Retry")
+
+val product = ProductDataUIModel(
+    id = "s",
+    name = "Product",
+    price = "$20",
+    picture = "",
+    freeShipping = true,
+    condition = "New",
+    address = "Miami, Florida",
+    shareableDescription = "Description",
+    storeLink = ""
+)
+
+val product2 = ProductDataUIModel(
+    id = "si",
+    name = "Product",
+    price = "$20",
+    picture = "",
+    freeShipping = true,
+    condition = "New",
+    address = "Miami, Florida",
+    shareableDescription = "Description",
+    storeLink = ""
+)
+
+val product3 = ProductDataUIModel(
+    id = "sa",
+    name = "Product",
+    price = "$20",
+    picture = "",
+    freeShipping = true,
+    condition = "New",
+    address = "Miami, Florida",
+    shareableDescription = "Description",
+    storeLink = ""
+)
+
+val productList = listOf(product, product2, product3)
 
 val searchResultActions = SearchResultsActions(
+    doWhenSearchActionClicked = {},
     doWhenBackButtonClicked = {})
+
+val searchResultsLoading = ProductSearchState.Loading
+
+val searchResults = ProductSearchState.Results(products = productList)
+
+val searchResultsNoResults = ProductSearchState.NoResults
+
+val searchResultsRefreshingError =
+    ProductSearchState.Results(products = productList, refreshingError = error)
+
+val searchResultsFailure = ProductSearchState.Failure(
+    ErrorUIModel(
+        generalPurposeMessage = "Opps! Something went wrong &#128550;",
+        suggestedAction = "Retry"
+    )
+)


### PR DESCRIPTION
- Create the composables for loading, result list and error result to be shown in the results screen
- Use the viewmodel initSearch in the products screen when the user taps on search button with a query search
- Add to the navigation component, the viewmodel state to pass the state to from the search product screen to the result screen.