### PR TITLE
Add Details Scree

### DIFF
--- a/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
@@ -41,6 +41,7 @@ class MainSearchActivity : ComponentActivity() {
 
     private fun setupActions(): MercadoSearchNavigationActions = MercadoSearchNavigationActions(
         doWhenSearchActionClicked = { text -> viewModel.initialSearch(text) },
+        doWhenShowProductDetails = {},
         doWhenBackButtonPressed = { onBackPressed() }
     )
 }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
@@ -18,9 +18,8 @@ import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchYellow
 import com.sandoval.mercadosearch.ui.compose.textFieldSaver
-import com.sandoval.mercadosearch.ui.search_products.screens.SearchProductScreen
-import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultScreen
-import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultsActions
+import com.sandoval.mercadosearch.ui.search_products.screens.*
+import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
 import com.sandoval.mercadosearch.ui.viewmodel.state.ProductSearchState
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -77,6 +76,15 @@ fun MercadoSearchNavigation(
                 )
             )
         }
+
+        composable(Route.DETAILS.name) {
+            SetStatusBarColor(systemUiController = systemUiController, color = MercadoSearchYellow)
+            ProductDetailScreen(
+                actions = productDetailsActions(
+                    mercadoSearchNavigationActions
+                )
+            )
+        }
     }
 }
 
@@ -93,8 +101,23 @@ private fun searchResultActions(
             searchTextValue.text
         )
     },
+    doOnSelectedProduct = { product ->
+        mercadoSearchNavigation.doWhenShowProductDetails(product)
+        navigationController.navigate(Route.DETAILS.name)
+    },
     doWhenBackButtonClicked = mercadoSearchNavigation.doWhenBackButtonPressed
 )
+
+@Composable
+private fun productDetailsActions(
+    mercadoSearchNavigation: MercadoSearchNavigationActions
+) =
+    ProductDetailsActions(
+        doWhenBackButtonClicked = {
+            mercadoSearchNavigation.doWhenBackButtonPressed()
+        }
+    )
+
 
 @Composable
 private fun SetStatusBarColor(systemUiController: SystemUiController, color: Color) {
@@ -105,6 +128,7 @@ private fun SetStatusBarColor(systemUiController: SystemUiController, color: Col
 
 data class MercadoSearchNavigationActions(
     val doWhenSearchActionClicked: (String) -> Unit,
+    val doWhenShowProductDetails: (ProductDataUIModel) -> Unit,
     val doWhenBackButtonPressed: () -> Unit
 )
 

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
@@ -1,0 +1,93 @@
+package com.sandoval.mercadosearch.ui.search_products.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import com.sandoval.mercadosearch.ui.compose.BackButton
+import com.sandoval.mercadosearch.ui.compose.ErrorSnackbarHost
+import com.sandoval.mercadosearch.ui.search_products.screens.preview.productDetailActions
+import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
+
+@Composable
+fun ProductDetailScreen(
+    actions: ProductDetailsActions
+) {
+    val scaffoldState = rememberScaffoldState()
+    Scaffold(
+        scaffoldState = scaffoldState,
+        topBar = {
+            TopAppBar(
+                title = {},
+                actions = { TopBarDetailScreenSection(actions) },
+                navigationIcon = { BackButton(actions.doWhenBackButtonClicked) }
+            )
+        },
+        snackbarHost = { snackbarHostState -> ErrorSnackbarHost(snackbarHostState = snackbarHostState) }
+    ) { paddingValues ->
+        BoxWithConstraints {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.White)
+                    .verticalScroll(
+                        rememberScrollState()
+                    )
+                    .padding(bottom = paddingValues.calculateBottomPadding())
+            ) {
+
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopBarDetailScreenSection(actions: ProductDetailsActions) {
+    IconButton(
+        onClick = {
+
+        }
+    ) {
+        Icon(
+            imageVector = Icons.Default.Share,
+            contentDescription = "Compartir",
+            tint = Color.White
+        )
+    }
+}
+
+data class ProductDetailsActions(
+    val doWhenBackButtonClicked: () -> Unit
+)
+
+@Preview(name = "ScreenState")
+@Preview(name = "Landscape", device = Devices.PIXEL_4_XL, widthDp = 720, heightDp = 360)
+@Composable
+fun ProductsDetailsScreenPreview() {
+    BuildProductDetailsPreview()
+}
+
+@Composable
+fun BuildProductDetailsPreview() {
+    MercadoSearchTheme() {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colors.background
+        ) {
+            ProductDetailScreen(
+                productDetailActions
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchResultsScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/SearchResultsScreen.kt
@@ -71,7 +71,8 @@ fun SearchResultScreen(
                 ProductSearchState.NoResults -> NoResultsFoundSection()
                 is ProductSearchState.Results -> {
                     ProductsListSection(
-                        searchState.products
+                        searchState.products,
+                        actions.doOnSelectedProduct
                     )
                     searchState.refreshingError?.let { error ->
                         ShowErrorSnackBar(
@@ -128,7 +129,8 @@ private fun LoadingSection() {
 
 @Composable
 private fun ProductsListSection(
-    products: List<ProductDataUIModel>
+    products: List<ProductDataUIModel>,
+    doOnSelectedProduct: (ProductDataUIModel) -> Unit
 ) {
     val lazyListState = rememberLazyListState()
     LazyColumn(
@@ -138,7 +140,7 @@ private fun ProductsListSection(
             items = products,
             key = { product -> product.id }) { product ->
             Row(
-                modifier = Modifier.clickable { },
+                modifier = Modifier.clickable { doOnSelectedProduct(product) },
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 AsyncImage(
@@ -232,7 +234,8 @@ private fun FailureSection(message: String) {
 data class SearchResultsActions(
     val doWhenSearchActionClicked: () -> Unit,
     val doWhenSearchedTextChanged: (TextFieldValue) -> Unit,
-    val doWhenBackButtonClicked: () -> Unit
+    val doWhenBackButtonClicked: () -> Unit,
+    val doOnSelectedProduct: (ProductDataUIModel) -> Unit
 )
 
 @Preview(name = "LoadingStateState")

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
@@ -1,11 +1,14 @@
 package com.sandoval.mercadosearch.ui.search_products.screens.preview
 
 import com.sandoval.mercadosearch.ui.base.ErrorUIModel
+import com.sandoval.mercadosearch.ui.search_products.screens.ProductDetailsActions
 import com.sandoval.mercadosearch.ui.search_products.screens.SearchResultsActions
-import com.sandoval.mercadosearch.ui.viewmodel.mapper.DProductDataModelToUIModel
 import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
 import com.sandoval.mercadosearch.ui.viewmodel.state.ProductSearchState
 
+/*
+Mock de modelos para simular los estados en los previews
+ */
 
 val error =
     ErrorUIModel(generalPurposeMessage = "Something went wrong", suggestedAction = "Retry")
@@ -48,9 +51,14 @@ val product3 = ProductDataUIModel(
 
 val productList = listOf(product, product2, product3)
 
+/*
+Estados de UI para la pantalla de Resultados de Busqueda
+ */
+
 val searchResultActions = SearchResultsActions(
     doWhenSearchActionClicked = {},
     doWhenSearchedTextChanged = {},
+    doOnSelectedProduct = {},
     doWhenBackButtonClicked = {})
 
 val searchResultsLoading = ProductSearchState.Loading
@@ -68,3 +76,9 @@ val searchResultsFailure = ProductSearchState.Failure(
         suggestedAction = "Retry"
     )
 )
+
+/*
+Estados de UI para la pantalla de Busqueda Inicial
+ */
+
+val productDetailActions = ProductDetailsActions(doWhenBackButtonClicked = {})


### PR DESCRIPTION
- Add the details screen with the share button and the back button
- Navigate from the search results screen to the details screen when user taps on any product of the list. Passing the UIModel through the navigation to be used in the future tot get all the information from the details api