### PR TITLE
Juansandoval/hu 015 implement share functionality on details screen

### DIFF
--- a/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/MainSearchActivity.kt
@@ -13,6 +13,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.sandoval.mercadosearch.ui.search_products.router.MercadoSearchNavigation
 import com.sandoval.mercadosearch.ui.search_products.router.MercadoSearchNavigationActions
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
+import com.sandoval.mercadosearch.ui.utils.shareText
 import com.sandoval.mercadosearch.ui.viewmodel.ProductsViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -42,6 +43,9 @@ class MainSearchActivity : ComponentActivity() {
     private fun setupActions(): MercadoSearchNavigationActions = MercadoSearchNavigationActions(
         doWhenSearchActionClicked = { text -> viewModel.initialSearch(text) },
         doWhenShowProductDetails = {},
+        doWhenSharedButtonClicked = { description ->
+            shareText(title = "Mercado Search App shared product", description)
+        },
         doWhenBackButtonPressed = { onBackPressed() }
     )
 }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/router/MercadoSearchNavigation.kt
@@ -113,6 +113,9 @@ private fun productDetailsActions(
     mercadoSearchNavigation: MercadoSearchNavigationActions
 ) =
     ProductDetailsActions(
+        doWhenSharedButtonClicked = { description ->
+            mercadoSearchNavigation.doWhenSharedButtonClicked(description)
+        },
         doWhenBackButtonClicked = {
             mercadoSearchNavigation.doWhenBackButtonPressed()
         }
@@ -129,6 +132,7 @@ private fun SetStatusBarColor(systemUiController: SystemUiController, color: Col
 data class MercadoSearchNavigationActions(
     val doWhenSearchActionClicked: (String) -> Unit,
     val doWhenShowProductDetails: (ProductDataUIModel) -> Unit,
+    val doWhenSharedButtonClicked: (String) -> Unit,
     val doWhenBackButtonPressed: () -> Unit
 )
 

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import com.sandoval.mercadosearch.ui.compose.BackButton
 import com.sandoval.mercadosearch.ui.compose.ErrorSnackbarHost
+import com.sandoval.mercadosearch.ui.search_products.screens.preview.product
 import com.sandoval.mercadosearch.ui.search_products.screens.preview.productDetailActions
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
+import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
 
 @Composable
 fun ProductDetailScreen(
@@ -30,7 +32,9 @@ fun ProductDetailScreen(
         topBar = {
             TopAppBar(
                 title = {},
-                actions = { TopBarDetailScreenSection(actions) },
+                //TODO Aqui se debe pasar es un parametro del modelo que comparte la descripcion del producto
+                // TODO Por ahora pasamos un string quemado para probar la funcionalidad mientras pintamos la informacion
+                actions = { TopBarDetailScreenSection("share", actions) },
                 navigationIcon = { BackButton(actions.doWhenBackButtonClicked) }
             )
         },
@@ -53,10 +57,10 @@ fun ProductDetailScreen(
 }
 
 @Composable
-private fun TopBarDetailScreenSection(actions: ProductDetailsActions) {
+private fun TopBarDetailScreenSection(product: String, actions: ProductDetailsActions) {
     IconButton(
         onClick = {
-
+            actions.doWhenSharedButtonClicked(product)
         }
     ) {
         Icon(
@@ -68,6 +72,7 @@ private fun TopBarDetailScreenSection(actions: ProductDetailsActions) {
 }
 
 data class ProductDetailsActions(
+    val doWhenSharedButtonClicked: (String) -> Unit,
     val doWhenBackButtonClicked: () -> Unit
 )
 

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/ProductDetailScreen.kt
@@ -9,18 +9,18 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.sandoval.mercadosearch.ui.compose.BackButton
 import com.sandoval.mercadosearch.ui.compose.ErrorSnackbarHost
-import com.sandoval.mercadosearch.ui.search_products.screens.preview.product
 import com.sandoval.mercadosearch.ui.search_products.screens.preview.productDetailActions
 import com.sandoval.mercadosearch.ui.theme.MercadoSearchTheme
-import com.sandoval.mercadosearch.ui.viewmodel.models.ProductDataUIModel
 
 @Composable
 fun ProductDetailScreen(
@@ -35,7 +35,12 @@ fun ProductDetailScreen(
                 //TODO Aqui se debe pasar es un parametro del modelo que comparte la descripcion del producto
                 // TODO Por ahora pasamos un string quemado para probar la funcionalidad mientras pintamos la informacion
                 actions = { TopBarDetailScreenSection("share", actions) },
-                navigationIcon = { BackButton(actions.doWhenBackButtonClicked) }
+                navigationIcon = {
+                    BackButton(actions.doWhenBackButtonClicked)
+                },
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = Color.Black,
+                elevation = 10.dp
             )
         },
         snackbarHost = { snackbarHostState -> ErrorSnackbarHost(snackbarHostState = snackbarHostState) }
@@ -66,7 +71,7 @@ private fun TopBarDetailScreenSection(product: String, actions: ProductDetailsAc
         Icon(
             imageVector = Icons.Default.Share,
             contentDescription = "Compartir",
-            tint = Color.White
+            tint = Color.Black
         )
     }
 }

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/search_products/screens/preview/MercadoSearchPreviewStates.kt
@@ -81,4 +81,5 @@ val searchResultsFailure = ProductSearchState.Failure(
 Estados de UI para la pantalla de Busqueda Inicial
  */
 
-val productDetailActions = ProductDetailsActions(doWhenBackButtonClicked = {})
+val productDetailActions =
+    ProductDetailsActions(doWhenSharedButtonClicked = {}, doWhenBackButtonClicked = {})

--- a/app/src/main/java/com/sandoval/mercadosearch/ui/utils/IntentActionsUtils.kt
+++ b/app/src/main/java/com/sandoval/mercadosearch/ui/utils/IntentActionsUtils.kt
@@ -1,0 +1,21 @@
+package com.sandoval.mercadosearch.ui.utils
+
+import android.app.Activity
+import android.content.Intent
+
+/**
+ * Esta extension ayuda a crear un intent implicito para compartir texto con otras apps.
+ * Pide al dispotivo un dialogo de opciones.
+ *
+ * @param title Titulo para el modal de opciones
+ * @param contentToShare Texto para compartir
+ *
+ * */
+
+fun Activity.shareText(title: String, contentToShare: String) {
+    startActivity(Intent.createChooser(Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT, contentToShare)
+        type = "text/plain"
+    }, title))
+}


### PR DESCRIPTION
- Add the share functionality to be able to share information in the future about the details of a product
- Add the intent chooser to be able to choose the app where the user wants to share information about the details of a product
- Minor color UI fix to the back arrow in the topAppBar component